### PR TITLE
`no-orphan-types`: Allow ignoring runtime package names

### DIFF
--- a/docs/rules/no-orphan-types.md
+++ b/docs/rules/no-orphan-types.md
@@ -20,7 +20,19 @@ This rule flags a `@types/*` package in `dependencies`/`devDependencies` that ha
 Type: `string[]`\
 Default: `[]`
 
-Additional `@types/*` package names to allow without a corresponding dependency. The built-in defaults (`@types/node`, `@types/bun`) are always ignored.
+Additional `@types/*` package names or corresponding runtime package names to allow without a corresponding dependency. For example, both `@types/foo` and `foo` ignore the `@types/foo` package. For scoped packages, both `@types/foo__bar` and `@foo/bar` are accepted. The built-in defaults (`@types/node`, `@types/bun`) are always ignored.
+
+```js
+'package-json/no-orphan-types': [
+	'error',
+	{
+		ignore: [
+			'chrome',
+			'react',
+		],
+	},
+]
+```
 
 ## Examples
 

--- a/rules/no-orphan-types.js
+++ b/rules/no-orphan-types.js
@@ -18,11 +18,11 @@ const messages = {
 const defaultIgnore = ['@types/node', '@types/bun'];
 
 /**
-Map an `@types/*` package name to the runtime package it provides types for.
+Get the runtime package name for an `@types/*` package.
 
 `@types/foo` → `foo`; `@types/foo__bar` → `@foo/bar` (the scoped-types convention).
 */
-const typesTarget = name => {
+const getTypesTarget = name => {
 	const subject = name.slice('@types/'.length);
 
 	return subject.includes('__') ? '@' + subject.replace('__', '/') : subject;
@@ -56,7 +56,7 @@ const create = context => {
 			}
 
 			for (const {member, name} of typeEntries) {
-				const target = typesTarget(name);
+				const target = getTypesTarget(name);
 
 				if (ignore.has(name) || ignore.has(target)) {
 					continue;

--- a/rules/no-orphan-types.js
+++ b/rules/no-orphan-types.js
@@ -56,11 +56,11 @@ const create = context => {
 			}
 
 			for (const {member, name} of typeEntries) {
-				if (ignore.has(name)) {
+				const target = typesTarget(name);
+
+				if (ignore.has(name) || ignore.has(target)) {
 					continue;
 				}
-
-				const target = typesTarget(name);
 
 				if (allNames.has(target)) {
 					continue;

--- a/test/no-orphan-types.js
+++ b/test/no-orphan-types.js
@@ -9,6 +9,8 @@ test.snapshot({
 		'{"dependencies": {"foo": "^1.0.0"}, "devDependencies": {"@types/foo": "^1.0.0"}}',
 		// Matching across groups.
 		'{"peerDependencies": {"react": "^18.0.0"}, "devDependencies": {"@types/react": "^18.0.0"}}',
+		// Matching through optionalDependencies.
+		'{"optionalDependencies": {"foo": "^1.0.0"}, "devDependencies": {"@types/foo": "^1.0.0"}}',
 		// Ambient type packages with no runtime counterpart are ignored by default.
 		'{"devDependencies": {"@types/node": "^20.0.0"}}',
 		'{"devDependencies": {"@types/bun": "^1.0.0"}}',
@@ -17,12 +19,19 @@ test.snapshot({
 		// User-supplied `ignore` accepts either the type package or runtime package name.
 		{code: '{"devDependencies": {"@types/foo": "^1.0.0"}}', options: [{ignore: ['@types/foo']}]},
 		{code: '{"devDependencies": {"@types/foo": "^1.0.0"}}', options: [{ignore: ['foo']}]},
+		{code: '{"devDependencies": {"@types/foo__bar": "^1.0.0"}}', options: [{ignore: ['@types/foo__bar']}]},
 		{code: '{"devDependencies": {"@types/foo__bar": "^1.0.0"}}', options: [{ignore: ['@foo/bar']}]},
 	],
 	invalid: [
 		`{
 	"devDependencies": {
 		"@types/foo": "^1.0.0"
+	}
+}`,
+		`{
+	"devDependencies": {
+		"@types/foo": "^1.0.0",
+		"bar": "^1.0.0"
 	}
 }`,
 		// Scoped types without the scoped package.

--- a/test/no-orphan-types.js
+++ b/test/no-orphan-types.js
@@ -14,8 +14,10 @@ test.snapshot({
 		'{"devDependencies": {"@types/bun": "^1.0.0"}}',
 		// Scoped types map to the scoped package.
 		'{"dependencies": {"@foo/bar": "^1.0.0"}, "devDependencies": {"@types/foo__bar": "^1.0.0"}}',
-		// User-supplied `ignore` exempts a package.
+		// User-supplied `ignore` accepts either the type package or runtime package name.
 		{code: '{"devDependencies": {"@types/foo": "^1.0.0"}}', options: [{ignore: ['@types/foo']}]},
+		{code: '{"devDependencies": {"@types/foo": "^1.0.0"}}', options: [{ignore: ['foo']}]},
+		{code: '{"devDependencies": {"@types/foo__bar": "^1.0.0"}}', options: [{ignore: ['@foo/bar']}]},
 	],
 	invalid: [
 		`{

--- a/test/no-orphan-types.js
+++ b/test/no-orphan-types.js
@@ -11,6 +11,9 @@ test.snapshot({
 		'{"peerDependencies": {"react": "^18.0.0"}, "devDependencies": {"@types/react": "^18.0.0"}}',
 		// Matching through optionalDependencies.
 		'{"optionalDependencies": {"foo": "^1.0.0"}, "devDependencies": {"@types/foo": "^1.0.0"}}',
+		// @types packages in optionalDependencies and peerDependencies are outside this rule's scope.
+		'{"optionalDependencies": {"@types/foo": "^1.0.0"}}',
+		'{"peerDependencies": {"@types/foo": "^1.0.0"}}',
 		// Ambient type packages with no runtime counterpart are ignored by default.
 		'{"devDependencies": {"@types/node": "^20.0.0"}}',
 		'{"devDependencies": {"@types/bun": "^1.0.0"}}',

--- a/test/snapshots/no-orphan-types.js.snapshot
+++ b/test/snapshots/no-orphan-types.js.snapshot
@@ -26,14 +26,46 @@ Suggestion 1/1: Remove the unused type package.:
 
 `;
 
-exports[`invalid(2): {\"devDependencies\": {\"@types/foo__bar\": \"^1.0.0\"}} 1`] = `
+exports[`invalid(2): {\n\t\"devDependencies\": {\n\t\t\"@types/foo\": \"^1.0.0\",\n\t\t\"bar\": \"^1.0.0\"\n\t}\n} 1`] = `
+
+[Input]
+  1 | {
+  2 | 	"devDependencies": {
+  3 | 		"@types/foo": "^1.0.0",
+  4 | 		"bar": "^1.0.0"
+  5 | 	}
+  6 | }
+
+`;
+
+exports[`invalid(2): {\n\t\"devDependencies\": {\n\t\t\"@types/foo\": \"^1.0.0\",\n\t\t\"bar\": \"^1.0.0\"\n\t}\n} 2`] = `
+
+Message:
+  1 | {
+  2 | 	"devDependencies": {
+> 3 | 		"@types/foo": "^1.0.0",
+    | 		^^^^^^^^^^^^ \`@types/foo\` has no corresponding \`foo\` dependency; the type package is unused.
+  4 | 		"bar": "^1.0.0"
+  5 | 	}
+  6 | }
+
+Suggestion 1/1: Remove the unused type package.:
+  1 | {
+  2 | 	"devDependencies": {
+  3 | 		"bar": "^1.0.0"
+  4 | 	}
+  5 | }
+
+`;
+
+exports[`invalid(3): {\"devDependencies\": {\"@types/foo__bar\": \"^1.0.0\"}} 1`] = `
 
 [Input]
   1 | {"devDependencies": {"@types/foo__bar": "^1.0.0"}}
 
 `;
 
-exports[`invalid(2): {\"devDependencies\": {\"@types/foo__bar\": \"^1.0.0\"}} 2`] = `
+exports[`invalid(3): {\"devDependencies\": {\"@types/foo__bar\": \"^1.0.0\"}} 2`] = `
 
 Message:
 > 1 | {"devDependencies": {"@types/foo__bar": "^1.0.0"}}
@@ -44,14 +76,14 @@ Suggestion 1/1: Remove the unused type package.:
 
 `;
 
-exports[`invalid(3): {\"dependencies\": {\"@types/foo\": \"^1.0.0\"}} 1`] = `
+exports[`invalid(4): {\"dependencies\": {\"@types/foo\": \"^1.0.0\"}} 1`] = `
 
 [Input]
   1 | {"dependencies": {"@types/foo": "^1.0.0"}}
 
 `;
 
-exports[`invalid(3): {\"dependencies\": {\"@types/foo\": \"^1.0.0\"}} 2`] = `
+exports[`invalid(4): {\"dependencies\": {\"@types/foo\": \"^1.0.0\"}} 2`] = `
 
 Message:
 > 1 | {"dependencies": {"@types/foo": "^1.0.0"}}


### PR DESCRIPTION
Fixes #9