### PR TITLE
`no-orphan-types`: Ignore more ambient type packages

### DIFF
--- a/docs/rules/no-orphan-types.md
+++ b/docs/rules/no-orphan-types.md
@@ -11,7 +11,7 @@
 
 A `@types/foo` package provides type definitions for a `foo` package. If `foo` is not a dependency anywhere, the `@types/foo` entry is dead weight, usually left behind after the runtime dependency was removed.
 
-This rule flags a `@types/*` package in `dependencies`/`devDependencies` that has no corresponding dependency. Scoped types follow the `@types/foo__bar` → `@foo/bar` convention. Ambient type packages with no runtime counterpart (`@types/node`, `@types/bun`) are ignored by default; add more with the `ignore` option.
+This rule flags a `@types/*` package in `dependencies`/`devDependencies` that has no corresponding dependency. Scoped types follow the `@types/foo__bar` → `@foo/bar` convention. Ambient type packages with no runtime counterpart (`@types/node`, `@types/bun`, `@types/chrome`) are ignored by default; see the [source file](../../rules/no-orphan-types.js) for the full list, and add more with the `ignore` option.
 
 ## Options
 
@@ -20,7 +20,7 @@ This rule flags a `@types/*` package in `dependencies`/`devDependencies` that ha
 Type: `string[]`\
 Default: `[]`
 
-Additional `@types/*` package names or corresponding runtime package names to allow without a corresponding dependency. For example, both `@types/foo` and `foo` ignore the `@types/foo` package. For scoped packages, both `@types/foo__bar` and `@foo/bar` are accepted. The built-in defaults (`@types/node`, `@types/bun`) are always ignored.
+Additional `@types/*` package names or corresponding runtime package names to allow without a corresponding dependency. For example, both `@types/foo` and `foo` ignore the `@types/foo` package. For scoped packages, both `@types/foo__bar` and `@foo/bar` are accepted. The built-in defaults (`@types/node`, `@types/bun`, `@types/chrome`) are always ignored; see the [source file](../../rules/no-orphan-types.js) for the full list.
 
 ```js
 'package-json/no-orphan-types': [

--- a/rules/no-orphan-types.js
+++ b/rules/no-orphan-types.js
@@ -15,7 +15,24 @@ const messages = {
 };
 
 // Ambient type packages that have no runtime counterpart.
-const defaultIgnore = ['@types/node', '@types/bun'];
+const defaultIgnore = [
+	'@types/node',
+	'@types/bun',
+	'@types/chrome',
+	'@types/deno',
+	'@types/firefox-webext-browser',
+	'@types/google-apps-script',
+	'@types/serviceworker',
+	'@types/cordova',
+	'@types/trusted-types',
+	'@types/web-bluetooth',
+	'@types/webxr',
+	'@types/w3c-web-usb',
+	'@types/w3c-web-hid',
+	'@types/w3c-web-serial',
+	'@types/w3c-image-capture',
+	'@types/webgl-ext',
+];
 
 /**
 Get the runtime package name for an `@types/*` package.

--- a/test/no-orphan-types.js
+++ b/test/no-orphan-types.js
@@ -17,6 +17,20 @@ test.snapshot({
 		// Ambient type packages with no runtime counterpart are ignored by default.
 		'{"devDependencies": {"@types/node": "^20.0.0"}}',
 		'{"devDependencies": {"@types/bun": "^1.0.0"}}',
+		'{"devDependencies": {"@types/chrome": "^0.0.1"}}',
+		'{"devDependencies": {"@types/deno": "^1.0.0"}}',
+		'{"devDependencies": {"@types/firefox-webext-browser": "^1.0.0"}}',
+		'{"devDependencies": {"@types/google-apps-script": "^1.0.0"}}',
+		'{"devDependencies": {"@types/serviceworker": "^1.0.0"}}',
+		'{"devDependencies": {"@types/cordova": "^1.0.0"}}',
+		'{"devDependencies": {"@types/trusted-types": "^1.0.0"}}',
+		'{"devDependencies": {"@types/web-bluetooth": "^1.0.0"}}',
+		'{"devDependencies": {"@types/webxr": "^1.0.0"}}',
+		'{"devDependencies": {"@types/w3c-web-usb": "^1.0.0"}}',
+		'{"devDependencies": {"@types/w3c-web-hid": "^1.0.0"}}',
+		'{"devDependencies": {"@types/w3c-web-serial": "^1.0.0"}}',
+		'{"devDependencies": {"@types/w3c-image-capture": "^1.0.0"}}',
+		'{"devDependencies": {"@types/webgl-ext": "^1.0.0"}}',
 		// Scoped types map to the scoped package.
 		'{"dependencies": {"@foo/bar": "^1.0.0"}, "devDependencies": {"@types/foo__bar": "^1.0.0"}}',
 		// User-supplied `ignore` accepts either the type package or runtime package name.


### PR DESCRIPTION
Fixes #6