### PR TITLE
`no-orphan-script-hooks`: Treat standalone git hook names as exempt

### DIFF
--- a/docs/rules/no-orphan-script-hooks.md
+++ b/docs/rules/no-orphan-script-hooks.md
@@ -11,7 +11,7 @@ npm runs `pre<name>` and `post<name>` scripts before and after `name`, respectiv
 
 npm lifecycle scripts such as `prepare`, `prepack`, and `preversion` are exempt because npm runs them independently. `preenv`, `postenv`, `prerestart`, and `postrestart` are also exempt because npm supplies implicit `env` and `restart` scripts. The rule does not inspect the filesystem, so a `prestart` hook that relies on npm's implicit `server.js` start script must be exempted with `ignore`.
 
-Common standalone tool names such as `postcss`, `prettier`, and `preview`, including namespaced variants, are ignored by default.
+Common standalone tool names such as `postcss`, `posthtml`, `prettier`, and `preview`, including namespaced variants, are ignored by default. Namespaced `prepare:*` scripts and Git hook scripts named `precommit`, `pre-commit`, `prepush`, or `pre-push` are also treated as standalone commands rather than `pre` hooks.
 
 No fix is provided because a hook-like name may be an intentionally standalone command, and only the package author can decide whether to remove it, add its target script, or ignore it.
 

--- a/rules/no-orphan-script-hooks.js
+++ b/rules/no-orphan-script-hooks.js
@@ -14,11 +14,11 @@ const messages = {
 
 const hookPrefixes = ['pre', 'post'];
 
-const commonStandaloneScriptPattern = /^(?:postcss|prettier|preview)(?::|$)/u;
+const standaloneScriptPattern = /^(?:postcss|posthtml|prepare|prettier|preview)(?::|$)/u;
+const standaloneGitHookNames = new Set(['precommit', 'pre-commit', 'prepush', 'pre-push']);
 
 // The npm CLI can run these scripts without a correspondingly named package script.
 const specialScriptNames = new Set([
-	'prepare',
 	'prepublish',
 	'prepublishOnly',
 	'prepack',
@@ -88,7 +88,8 @@ const create = context => {
 
 				if (
 					specialScriptNames.has(hook)
-					|| commonStandaloneScriptPattern.test(hook)
+					|| standaloneScriptPattern.test(hook)
+					|| standaloneGitHookNames.has(hook)
 					|| isIgnoredName(hook, ignoredPatterns)
 				) {
 					continue;

--- a/test/no-orphan-script-hooks.js
+++ b/test/no-orphan-script-hooks.js
@@ -42,6 +42,11 @@ test.snapshot({
 		'{"scripts": {"prettier": "prettier --check .", "prettier:fix": "prettier --write ."}}',
 		'{"scripts": {"preview": "vite preview", "preview:production": "vite preview --mode production"}}',
 		'{"scripts": {"postcss": "postcss src/index.css", "postcss:build": "postcss src/index.css"}}',
+		'{"scripts": {"posthtml": "posthtml -o output.html -i input.html", "posthtml:build": "posthtml -o output.html -i input.html"}}',
+		// Namespaced `prepare` scripts are standalone commands, not `pre` hooks.
+		'{"scripts": {"prepare:safari": "npm run build"}}',
+		// Git hook script names are standalone commands, not `pre` hooks.
+		'{"scripts": {"precommit": "lint-staged", "pre-commit": "lint-staged", "prepush": "npm test", "pre-push": "npm test"}}',
 		// Standalone names can be exempted explicitly.
 		{code: '{"scripts": {"preflight": "npm run check"}}', options: [{ignore: ['^preflight$']}]},
 		{code: '{"scripts": {"prebuild": "npm run build", "pretest": "npm test"}}', options: [{ignore: [/^pre/g]}]},
@@ -58,6 +63,9 @@ test.snapshot({
 		'{"scripts": {"prestart": "npm run setup"}}',
 		'{"scripts": {"prebuild": "npm run clean", "posttest": "npm run clean"}}',
 		'{"scripts": {"prettierx": "echo no", "previewing": "echo no", "postcssx": "echo no"}}',
+		'{"scripts": {"prebuild:watch": "npm run clean"}}',
+		// Namespaced Git-like names remain hooks and need a matching target.
+		'{"scripts": {"precommit:lint": "lint-staged", "pre-commit:checks": "lint-staged", "prepush:ci": "npm test", "pre-push:checks": "npm test"}}',
 		// A standalone command with a hook-like name needs `ignore`.
 		'{"scripts": {"preflight": "npm run check"}}',
 	],

--- a/test/snapshots/no-orphan-script-hooks.js.snapshot
+++ b/test/snapshots/no-orphan-script-hooks.js.snapshot
@@ -105,14 +105,68 @@ Message:
 
 `;
 
-exports[`invalid(6): {\"scripts\": {\"preflight\": \"npm run check\"}} 1`] = `
+exports[`invalid(6): {\"scripts\": {\"prebuild:watch\": \"npm run clean\"}} 1`] = `
+
+[Input]
+  1 | {"scripts": {"prebuild:watch": "npm run clean"}}
+
+`;
+
+exports[`invalid(6): {\"scripts\": {\"prebuild:watch\": \"npm run clean\"}} 2`] = `
+
+Message:
+> 1 | {"scripts": {"prebuild:watch": "npm run clean"}}
+    |              ^^^^^^^^^^^^^^^^ The \`prebuild:watch\` script has no corresponding \`build:watch\` script.
+
+`;
+
+exports[`invalid(7): {\"scripts\": {\"precommit:lint\": \"lint-staged\", \"pre-commit:checks\": \"lint-staged\", \"prepush:ci\": \"npm test\", \"pre-push:checks\": \"npm test\"}} 1`] = `
+
+[Input]
+  1 | {"scripts": {"precommit:lint": "lint-staged", "pre-commit:checks": "lint-staged", "prepush:ci": "npm test", "pre-push:checks": "npm test"}}
+
+`;
+
+exports[`invalid(7): {\"scripts\": {\"precommit:lint\": \"lint-staged\", \"pre-commit:checks\": \"lint-staged\", \"prepush:ci\": \"npm test\", \"pre-push:checks\": \"npm test\"}} 2`] = `
+
+Message:
+> 1 | {"scripts": {"precommit:lint": "lint-staged", "pre-commit:checks": "lint-staged", "prepush:ci": "npm test", "pre-push:checks": "npm test"}}
+    |              ^^^^^^^^^^^^^^^^ The \`precommit:lint\` script has no corresponding \`commit:lint\` script.
+
+`;
+
+exports[`invalid(7): {\"scripts\": {\"precommit:lint\": \"lint-staged\", \"pre-commit:checks\": \"lint-staged\", \"prepush:ci\": \"npm test\", \"pre-push:checks\": \"npm test\"}} 3`] = `
+
+Message:
+> 1 | {"scripts": {"precommit:lint": "lint-staged", "pre-commit:checks": "lint-staged", "prepush:ci": "npm test", "pre-push:checks": "npm test"}}
+    |                                               ^^^^^^^^^^^^^^^^^^^ The \`pre-commit:checks\` script has no corresponding \`-commit:checks\` script.
+
+`;
+
+exports[`invalid(7): {\"scripts\": {\"precommit:lint\": \"lint-staged\", \"pre-commit:checks\": \"lint-staged\", \"prepush:ci\": \"npm test\", \"pre-push:checks\": \"npm test\"}} 4`] = `
+
+Message:
+> 1 | {"scripts": {"precommit:lint": "lint-staged", "pre-commit:checks": "lint-staged", "prepush:ci": "npm test", "pre-push:checks": "npm test"}}
+    |                                                                                   ^^^^^^^^^^^^ The \`prepush:ci\` script has no corresponding \`push:ci\` script.
+
+`;
+
+exports[`invalid(7): {\"scripts\": {\"precommit:lint\": \"lint-staged\", \"pre-commit:checks\": \"lint-staged\", \"prepush:ci\": \"npm test\", \"pre-push:checks\": \"npm test\"}} 5`] = `
+
+Message:
+> 1 | {"scripts": {"precommit:lint": "lint-staged", "pre-commit:checks": "lint-staged", "prepush:ci": "npm test", "pre-push:checks": "npm test"}}
+    |                                                                                                             ^^^^^^^^^^^^^^^^^ The \`pre-push:checks\` script has no corresponding \`-push:checks\` script.
+
+`;
+
+exports[`invalid(8): {\"scripts\": {\"preflight\": \"npm run check\"}} 1`] = `
 
 [Input]
   1 | {"scripts": {"preflight": "npm run check"}}
 
 `;
 
-exports[`invalid(6): {\"scripts\": {\"preflight\": \"npm run check\"}} 2`] = `
+exports[`invalid(8): {\"scripts\": {\"preflight\": \"npm run check\"}} 2`] = `
 
 Message:
 > 1 | {"scripts": {"preflight": "npm run check"}}


### PR DESCRIPTION
Fixes #23